### PR TITLE
Change ' ' to '.' in showSquare to represent empty square

### DIFF
--- a/Chess.hs
+++ b/Chess.hs
@@ -30,7 +30,7 @@ type Square = Maybe Piece
 
 -- | Show a square using FEN notation or ' ' for an empty square.
 showSquare :: Square -> Char
-showSquare = maybe ' ' showPiece
+showSquare = maybe '.' showPiece
 
 -- | Read a square using FEN notation or ' ' for an empty square.
 readSquare :: Char -> Either String Square


### PR DESCRIPTION
In episode two it was decided that . would be used instead of space to represent empty squares.
All other locations were changed but showSquare was left using space.

This pull request simply changes it to use a period.
